### PR TITLE
Scale collider based on bounding box

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -40,7 +40,7 @@ jobs:
     deploy-pages:
         needs: package
         runs-on: ubuntu-latest
-        #  if: ${{ format('refs/heads/{0}', github.event.repository.default_branch) == github.ref }}
+        if: ${{ format('refs/heads/{0}', github.event.repository.default_branch) == github.ref }}
         steps:
             - name: Deploy to GitHub Pages
               uses: actions/deploy-pages@v4

--- a/packages/react-ui/js/constants.ts
+++ b/packages/react-ui/js/constants.ts
@@ -5,3 +5,4 @@ export const debug = DEBUG_RENDERER ? console.log : () => {};
 export const TEXT_BASE_SIZE = 12;
 export const DEFAULT_FONT_SIZE = 50;
 export const Z_INC = 0.001;
+export const COLLIDER_THICKNESS = 0.05;

--- a/packages/react-ui/js/renderer.ts
+++ b/packages/react-ui/js/renderer.ts
@@ -902,7 +902,15 @@ export class Context {
             const height = node.node.getComputedHeight();
 
             if (isNaN(left) || isNaN(top) || isNaN(width) || isNaN(height)) {
-                throw new Error('Context.computeUIBounds: Invalid layout values detected');
+                const invalids = [];
+                if (isNaN(left)) invalids.push(`left=${left}`);
+                if (isNaN(top)) invalids.push(`top=${top}`);
+                if (isNaN(width)) invalids.push(`width=${width}`);
+                if (isNaN(height)) invalids.push(`height=${height}`);
+                throw new Error(
+                    `Context.computeUIBounds: Invalid layout values detected for node tag="${node.tag}"` +
+                        ` [${invalids.join(', ')}]`
+                );
             }
             minX = Math.min(minX, left);
             maxX = Math.max(maxX, left + width);

--- a/packages/react-ui/js/renderer.ts
+++ b/packages/react-ui/js/renderer.ts
@@ -1067,7 +1067,7 @@ export abstract class ReactUiBase extends Component implements ReactComp {
 
             extents[0] = 0.5 * scaledWidth * rootScaling[0]; // Half-width, scaled
             extents[1] = 0.5 * scaledHeight * rootScaling[1]; // Half-height, scaled
-            extents[2] = COLLIDER_THICKNESS; // Keep fixed depth
+            extents[2] = COLLIDER_THICKNESS / 2; // Keep fixed depth
 
             collision.extents.set(extents);
         }
@@ -1174,7 +1174,7 @@ export abstract class ReactUiBase extends Component implements ReactComp {
             const extents = this.object.getScalingWorld(new Float32Array(3));
             extents[0] *= 0.5 * this.width * this.scaling[0];
             extents[1] *= 0.5 * this.height * this.scaling[1];
-            extents[2] = COLLIDER_THICKNESS;
+            extents[2] = COLLIDER_THICKNESS / 2; // Keep fixed depth
             collision.extents.set(extents);
 
             this._colliderObject.setPositionLocal([

--- a/packages/react-ui/js/renderer.ts
+++ b/packages/react-ui/js/renderer.ts
@@ -1180,7 +1180,7 @@ export abstract class ReactUiBase extends Component implements ReactComp {
             this._colliderObject.setPositionLocal([
                 this.width * 0.5 * this.scaling[0],
                 -this.height * 0.5 * this.scaling[1],
-                0.025,
+                COLLIDER_THICKNESS / 2,
             ]);
         } else {
             this.engine.onResize.add(this._onViewportResize);

--- a/packages/react-ui/js/renderer.ts
+++ b/packages/react-ui/js/renderer.ts
@@ -908,7 +908,7 @@ export class Context {
                 if (isNaN(width)) invalids.push(`width=${width}`);
                 if (isNaN(height)) invalids.push(`height=${height}`);
                 throw new Error(
-                    `Context.computeUIBounds: Invalid layout values detected for node tag="${node.tag}"` +
+                    `Context.computeUIBounds: Invalid layout values detected for node tag="${node.tag ?? 'unknown'}"` +
                         ` [${invalids.join(', ')}]`
                 );
             }

--- a/packages/react-ui/js/renderer.ts
+++ b/packages/react-ui/js/renderer.ts
@@ -4,6 +4,7 @@ import {
     CollisionComponent,
     Component,
     Material,
+    ProjectionType,
     TextEffect,
     VerticalAlignment,
     ViewComponent,
@@ -17,7 +18,13 @@ import {Object3D, TextComponent, TextWrapMode, Font} from '@wonderlandengine/api
 
 import {propsEqual} from './helpers/props-helpers.js';
 import {version as reactVersion} from 'react';
-import {debug, DEBUG_EVENTS, DEFAULT_FONT_SIZE, TEXT_BASE_SIZE} from './constants.js';
+import {
+    COLLIDER_THICKNESS,
+    debug,
+    DEBUG_EVENTS,
+    DEFAULT_FONT_SIZE,
+    TEXT_BASE_SIZE,
+} from './constants.js';
 export type {
     ValueType,
     ValueTypeNoAuto,
@@ -874,6 +881,40 @@ export class Context {
             this.printTree(n, prefix + '--');
         }
     }
+
+    computeUIBounds(): {minX: number; maxX: number; minY: number; maxY: number} {
+        if (!this.root) return {minX: 0, maxX: 0, minY: 0, maxY: 0};
+
+        const rootLeft = this.root.node.getComputedLeft();
+        const rootTop = this.root.node.getComputedTop();
+        const rootWidth = this.root.node.getComputedWidth();
+        const rootHeight = this.root.node.getComputedHeight();
+
+        let minX = rootLeft,
+            maxX = rootLeft + rootWidth,
+            minY = rootTop,
+            maxY = rootTop + rootHeight;
+
+        const traverse = (node: NodeWrapper) => {
+            const left = node.node.getComputedLeft();
+            const top = node.node.getComputedTop();
+            const width = node.node.getComputedWidth();
+            const height = node.node.getComputedHeight();
+
+            if (isNaN(left) || isNaN(top) || isNaN(width) || isNaN(height)) {
+                throw new Error('Context.computeUIBounds: Invalid layout values detected');
+            }
+            minX = Math.min(minX, left);
+            maxX = Math.max(maxX, left + width);
+            minY = Math.min(minY, top);
+            maxY = Math.max(maxY, top + height);
+
+            node.children.forEach(traverse);
+        };
+
+        traverse(this.root);
+        return {minX, maxX, minY, maxY};
+    }
 }
 
 export abstract class ReactUiBase extends Component implements ReactComp {
@@ -934,6 +975,8 @@ export abstract class ReactUiBase extends Component implements ReactComp {
         }
     }
 
+    private _colliderObject?: Object3D;
+
     static onRegister(engine: WonderlandEngine) {
         engine.registerComponent(CursorTarget);
     }
@@ -957,7 +1000,13 @@ export abstract class ReactUiBase extends Component implements ReactComp {
         this.width = this._dpiAdjust(this.engine.canvas.clientWidth);
         this.height = this._dpiAdjust(this.engine.canvas.clientHeight);
         this.scaling = [1 / this.width, 1 / this.width];
-        this.object.setPositionLocal(topLeft);
+
+        if (activeView.projectionType == ProjectionType.Orthographic) {
+            this.object.setPositionLocal([topLeft[0], topLeft[1], -1]);
+        } else {
+            this.object.setPositionLocal(topLeft);
+        }
+
         this.needsUpdate = true;
         this.viewportChanged = true;
     };
@@ -989,6 +1038,40 @@ export abstract class ReactUiBase extends Component implements ReactComp {
         );
 
         applyLayoutToSceneGraph(this.ctx.root, this.ctx!, this.viewportChanged);
+
+        if (this.space === UISpace.World && this._colliderObject) {
+            const bounds = this.ctx.computeUIBounds();
+            const width = bounds.maxX - bounds.minX;
+            const height = bounds.maxY - bounds.minY;
+            const centerX = (bounds.minX + bounds.maxX) / 2;
+            const centerY = (bounds.minY + bounds.maxY) / 2;
+
+            const rootScaling = this.object.getScalingWorld(tempScale);
+
+            // Adjust for scaling
+            const scaledWidth = width * this.scaling[0];
+            const scaledHeight = height * this.scaling[1];
+            const scaledCenterX = centerX * this.scaling[0];
+            const scaledCenterY = -centerY * this.scaling[1]; // Flip Y for Wonderland coords
+
+            // Update collider position (center of bounds)
+            this._colliderObject.setPositionLocal([
+                scaledCenterX,
+                scaledCenterY,
+                COLLIDER_THICKNESS / 2,
+            ]);
+
+            // Update extents (half-size)
+            const collision = this._colliderObject.getComponent(CollisionComponent)!;
+            const extents = new Float32Array(3);
+
+            extents[0] = 0.5 * scaledWidth * rootScaling[0]; // Half-width, scaled
+            extents[1] = 0.5 * scaledHeight * rootScaling[1]; // Half-height, scaled
+            extents[2] = COLLIDER_THICKNESS; // Keep fixed depth
+
+            collision.extents.set(extents);
+        }
+
         this.needsUpdate = false;
     }
 
@@ -1045,7 +1128,7 @@ export abstract class ReactUiBase extends Component implements ReactComp {
 
     override onActivate(): void {
         if (this.space == UISpace.World) {
-            const colliderObject =
+            this._colliderObject =
                 this.object.findByNameDirect('UIColliderObject')[0] ??
                 (() => {
                     const o = this.engine.scene.addObject(this.object);
@@ -1057,8 +1140,8 @@ export abstract class ReactUiBase extends Component implements ReactComp {
                     });
                     return o;
                 })();
-            const target = colliderObject.getComponent(CursorTarget)!;
-            const collision = colliderObject.getComponent(CollisionComponent)!;
+            const target = this._colliderObject.getComponent(CursorTarget)!;
+            const collision = this._colliderObject.getComponent(CollisionComponent)!;
             target.onClick.add(
                 (_, c, e) => {
                     const [x, y] = this.getCursorPosition(c as Cursor);
@@ -1091,10 +1174,10 @@ export abstract class ReactUiBase extends Component implements ReactComp {
             const extents = this.object.getScalingWorld(new Float32Array(3));
             extents[0] *= 0.5 * this.width * this.scaling[0];
             extents[1] *= 0.5 * this.height * this.scaling[1];
-            extents[2] = 0.05;
+            extents[2] = COLLIDER_THICKNESS;
             collision.extents.set(extents);
 
-            colliderObject.setPositionLocal([
+            this._colliderObject.setPositionLocal([
                 this.width * 0.5 * this.scaling[0],
                 -this.height * 0.5 * this.scaling[1],
                 0.025,
@@ -1109,9 +1192,8 @@ export abstract class ReactUiBase extends Component implements ReactComp {
 
     override onDeactivate(): void {
         if (this.space == UISpace.World) {
-            const colliderObject = this.object.findByNameDirect('UIColliderObject')[0];
-            if (!colliderObject) return;
-            const target = colliderObject.getComponent(CursorTarget)!;
+            if (!this._colliderObject) return;
+            const target = this._colliderObject.getComponent(CursorTarget)!;
             if (!target) return;
             // FIXME: We might be able to just deactivate the target here instead?
             target.onClick.remove('onClick');

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -16,10 +16,9 @@
         "build:dev": "tsc --sourceMap",
         "watch": "tsc --watch",
         "prepack": "npm run build",
-        "test": "npm run build && web-test-runner",
         "test:unit": "vitest --run",
         "test:unit:watch": "vitest",
-        "test:ci": "npm run build && vitest run && web-test-runner"
+        "test:ci": "npm run build && npm run test:unit"
     },
     "files": [
         "dist/**/*.d.ts",

--- a/packages/react-ui/test/unit/renderer.test.ts
+++ b/packages/react-ui/test/unit/renderer.test.ts
@@ -79,4 +79,59 @@ describe('Context', () => {
             expect(context.config).toBe(mockConfig);
         });
     });
+
+    describe('computeUIBounds', () => {
+        it('should compute UI bounds', () => {
+            const mockComp = mock<ReactComp>();
+            const mockYoga = mock<Yoga>();
+            const mockConfig = mock<Config>();
+            mockYoga.Config.create = vi.fn(() => mockConfig);
+            const context = new Context(mockComp, mockYoga);
+            context.root = mock<NodeWrapper>();
+            context.root.children = [];
+            context.root.node = mock<Node>();
+
+            const minX = 10;
+            const minY = 20;
+            const width = 30;
+            const height = 40;
+
+            context.root.node.getComputedLeft = vi.fn(() => minX);
+            context.root.node.getComputedTop = vi.fn(() => minY);
+            context.root.node.getComputedWidth = vi.fn(() => width);
+            context.root.node.getComputedHeight = vi.fn(() => height);
+
+            const bounds = context.computeUIBounds();
+
+            expect(bounds.minX).toEqual(minX);
+            expect(bounds.maxX).toEqual(minX + width);
+            expect(bounds.minY).toEqual(minY);
+            expect(bounds.maxY).toEqual(minY + height);
+        });
+
+        it('should handle NaN with an error', () => {
+            const mockComp = mock<ReactComp>();
+            const mockYoga = mock<Yoga>();
+            const mockConfig = mock<Config>();
+            mockYoga.Config.create = vi.fn(() => mockConfig);
+            const context = new Context(mockComp, mockYoga);
+            context.root = mock<NodeWrapper>();
+            context.root.children = [];
+            context.root.node = mock<Node>();
+
+            const minX = NaN;
+            const minY = NaN;
+            const width = NaN;
+            const height = NaN;
+
+            context.root.node.getComputedLeft = vi.fn(() => minX);
+            context.root.node.getComputedTop = vi.fn(() => minY);
+            context.root.node.getComputedWidth = vi.fn(() => width);
+            context.root.node.getComputedHeight = vi.fn(() => height);
+
+            expect(() => {
+                context.computeUIBounds();
+            }).toThrowError('Context.computeUIBounds: Invalid layout values detected');
+        });
+    });
 });


### PR DESCRIPTION
Recalculate the collider extends when the layout changes. This ensures that the collider is always the right size, no matter what the original size was.

Note:
For now this PR is on top of the `improvements` branch. That needs to be merged first, then after this one is rebased it can be merged as well. 